### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -145,10 +145,13 @@ document.addEventListener('DOMContentLoaded', () => {
         cart.forEach((item, index) => {
             const li = document.createElement('li');
             li.classList.add('cart-item');
-            li.innerHTML = `
-                ${item.name} - $${item.price.toFixed(2)}
-                <button class="remove-item" data-index="${index}">Remove</button>
-            `;
+            const textNode = document.createTextNode(`${item.name} - $${item.price.toFixed(2)}`);
+            li.appendChild(textNode);
+            const removeButton = document.createElement('button');
+            removeButton.classList.add('remove-item');
+            removeButton.setAttribute('data-index', index);
+            removeButton.textContent = 'Remove';
+            li.appendChild(removeButton);
             cartItemsElement.appendChild(li);
             total += item.price;
         });


### PR DESCRIPTION
Fixes [https://github.com/Chedder78/store/security/code-scanning/4](https://github.com/Chedder78/store/security/code-scanning/4)

To fix the problem, we need to ensure that any text content extracted from the DOM and inserted back into the HTML is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a text node or a safe method to set the text content instead of using innerHTML.

- Replace the usage of `innerHTML` with a method that safely sets the text content.
- Specifically, create text nodes for the product name and append them to the list item element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Ensure text content extracted from the DOM is properly escaped to prevent XSS attacks by replacing the usage of innerHTML with a safer method.